### PR TITLE
Add PSD tests and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,24 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: |
+        pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+matplotlib
+pytest

--- a/tests/test_psd.py
+++ b/tests/test_psd.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+from spectral_analysis_tools import PSD
+
+
+def test_psd_output_shapes():
+    rng = np.random.default_rng(0)
+    M, N = 3, 128
+    data = rng.normal(size=(M, N))
+    result = PSD(data, dt=1.0, Ndist=10, verbose=False)
+
+    assert 'freq' in result
+    assert 'Lambda' in result
+    assert 'Lambda_ci' in result
+
+    nfreq = N // 2 + 1
+    assert result['freq'].shape == (nfreq,)
+    assert result['Lambda'].shape == (nfreq,)
+    assert result['Lambda_ci'].shape == (nfreq, 2)


### PR DESCRIPTION
## Summary
- add `tests/` directory for pytest
- write a simple PSD shape test using generated data
- add `requirements.txt`
- configure GitHub Actions to run tests on pushes and PRs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6875c0cb7fb48330a9ecd1e4d0db6e24